### PR TITLE
Adding HA option for Grafana

### DIFF
--- a/helm-chart-sources/bluescape-monitoring-grafana/templates/grafana.yaml
+++ b/helm-chart-sources/bluescape-monitoring-grafana/templates/grafana.yaml
@@ -7,6 +7,13 @@ items:
     labels: {{- include "bluescape-monitoring-grafana.labels" . | nindent 6 }}
   spec:
     config:
+      {{- if .Values.ha_mode }}
+      deployment:
+        replicas: 3
+        envFrom:
+          - secretRef:
+              name: postgres-grafana-auth
+      {{- end }}
       auth:
         disable_login_form: {{ .Values.grafana.config.auth.disable_login_form }}
         disable_signout_menu: {{ .Values.grafana.config.auth.disable_signout_menu }}
@@ -40,6 +47,14 @@ items:
         domain: "grafana.{{ .Values.grafana.domain_name }}"
         root_url: "https://%(domain)s"
         serve_from_sub_path: false
+      {{- if .Values.ha_mode }}
+      database:
+        type: postgres
+        host: postgres.grafana:5432
+        name: grafana
+        username: "$__env{POSTGRES_USER}"
+        password: "$__env{POSTGRES_PASSWORD}"
+      {{- end }}
     dashboardLabelSelector:
     - matchExpressions:
       - key: app.kubernetes.io/instance

--- a/helm-chart-sources/bluescape-monitoring-grafana/templates/postgres-kubedb-init-script.yaml
+++ b/helm-chart-sources/bluescape-monitoring-grafana/templates/postgres-kubedb-init-script.yaml
@@ -1,0 +1,11 @@
+{{- if .Values.ha_mode }}
+apiVersion: v1
+data:
+  init.sql: |
+    CREATE DATABASE grafana;
+kind: ConfigMap
+metadata:
+  labels:
+    name: postgres-grafana-init-script
+  name: postgres-grafana-init-script
+{{- end }}

--- a/helm-chart-sources/bluescape-monitoring-grafana/templates/postgres-kubedb.yaml
+++ b/helm-chart-sources/bluescape-monitoring-grafana/templates/postgres-kubedb.yaml
@@ -1,0 +1,43 @@
+{{- if .Values.ha_mode }}
+apiVersion: kubedb.com/v1alpha1
+kind: Postgres
+metadata:
+  name: postgres-grafana
+spec:
+  replicas: 3
+  standbyMode: hot
+  databaseSecret:
+    secretName: postgres-grafana-auth
+  init:
+    scriptSource:
+      configMap:
+        name: postgres-grafana-init-script
+  leaderElection:
+    leaseDurationSeconds: 15
+    renewDeadlineSeconds: 10
+    retryPeriodSeconds: 2
+  podTemplate:
+    controller: {}
+    metadata: {}
+    spec:
+      resources: {}
+      serviceAccountName: postgres
+  replicaServiceTemplate:
+    metadata: {}
+    spec: {}
+  serviceTemplate:
+    metadata: {}
+    spec: {}
+  storage:
+    accessModes:
+    - ReadWriteOnce
+    resources:
+      requests:
+        storage: 10Gi
+    storageClassName: gp2
+  storageType: Durable
+  terminationPolicy: WipeOut
+  updateStrategy:
+    type: RollingUpdate
+  version: "11.1"
+  {{- end }}

--- a/helm-chart-sources/bluescape-monitoring-grafana/values.yaml
+++ b/helm-chart-sources/bluescape-monitoring-grafana/values.yaml
@@ -9,6 +9,11 @@ grafana:
   domain_name: example.io
   cluster_id: example
 
+  # Deploy cluster in HA Mode - 3 replicas with PostgreSQL database cluster
+  # deployed with kubedb
+  # Requires kubedb generated postgresql secret called "postgres-grafana-auth"
+  ha_mode: false
+
   config:
     auth:
       users:


### PR DESCRIPTION
Setting `ha_enabled: true` in helm chart causes it to configure a 3 replica Grafana cluster with a 3 node postgresql database cluster using kubedb custom resource.