### PR TITLE
OC-8750: feat: addition of two dashboards

### DIFF
--- a/helm-chart-sources/bluescape-monitoring-dashboards/README.md
+++ b/helm-chart-sources/bluescape-monitoring-dashboards/README.md
@@ -116,7 +116,7 @@ $ kctx atreus
 Switched to context "arn:aws:eks:us-west-2:429863676324:cluster/atreus".
 
 $ cd <repo>/helm-charts/helm-chart-sources
-$ helm --debug --dry-run upgrade --install -n grafana /bluescape-monitoring-dashboards
+$ helm upgrade --install grafana-dashboards-atreus bluescape-monitoring-dashboards -n grafana --dry-run
 ```
 
 This should give a lot of useful output and no errors.
@@ -128,7 +128,7 @@ $ kctx atreus
 Switched to context "arn:aws:eks:us-west-2:429863676324:cluster/atreus".
 
 $ cd <repo>/helm-charts/helm-chart-sources
-$ helm upgrade --install -n grafana /bluescape-monitoring-dashboards
+$ helm upgrade --install grafana-dashboards-atreus bluescape-monitoring-dashboards -n grafana
 ```
 
 This should not fail. Once this completes, login to grafana on the test cluster

--- a/helm-chart-sources/bluescape-monitoring-dashboards/templates/80_filedescriptors_by_ns/configmap.yaml
+++ b/helm-chart-sources/bluescape-monitoring-dashboards/templates/80_filedescriptors_by_ns/configmap.yaml
@@ -2,12 +2,12 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: filedescriptorusagebynamespace-dashboard
+  name: filedescriptors-usage-by-namespace-dashboard
   namespace: grafana
   labels:
      {{- include "bluescape-monitoring-dashboards.labels" . | nindent 4 }}
 data:
-  filedescriptorusagebynamespace-dashboard.json: |-
+  filedescriptors-usage-by-namespace-dashboard.json: |-
     {
       "annotations": {
         "list": [
@@ -25,8 +25,8 @@ data:
       "editable": true,
       "gnetId": null,
       "graphTooltip": 0,
-      "id": 53,
-      "iteration": 1619042641217,
+      "id": 133,
+      "iteration": 1619141130184,
       "links": [],
       "panels": [
         {
@@ -141,10 +141,10 @@ data:
               "selected": true,
               "tags": [],
               "text": [
-                "vault-secrets-webhook"
+                "All"
               ],
               "value": [
-                "vault-secrets-webhook"
+                "$__all"
               ]
             },
             "datasource": "Prometheus",
@@ -154,135 +154,9 @@ data:
             "label": "Namespace",
             "multi": true,
             "name": "namespace",
-            "options": [
-              {
-                "selected": false,
-                "text": "All",
-                "value": "$__all"
-              },
-              {
-                "selected": false,
-                "text": "ambassador",
-                "value": "ambassador"
-              },
-              {
-                "selected": false,
-                "text": "argocd",
-                "value": "argocd"
-              },
-              {
-                "selected": false,
-                "text": "auth-system",
-                "value": "auth-system"
-              },
-              {
-                "selected": false,
-                "text": "cert-manager",
-                "value": "cert-manager"
-              },
-              {
-                "selected": false,
-                "text": "cluster-autoscaler",
-                "value": "cluster-autoscaler"
-              },
-              {
-                "selected": false,
-                "text": "default",
-                "value": "default"
-              },
-              {
-                "selected": false,
-                "text": "dex",
-                "value": "dex"
-              },
-              {
-                "selected": false,
-                "text": "external-dns",
-                "value": "external-dns"
-              },
-              {
-                "selected": false,
-                "text": "external-secrets",
-                "value": "external-secrets"
-              },
-              {
-                "selected": false,
-                "text": "grafana",
-                "value": "grafana"
-              },
-              {
-                "selected": false,
-                "text": "ingress-nginx",
-                "value": "ingress-nginx"
-              },
-              {
-                "selected": false,
-                "text": "kafka",
-                "value": "kafka"
-              },
-              {
-                "selected": false,
-                "text": "kube-node-lease",
-                "value": "kube-node-lease"
-              },
-              {
-                "selected": false,
-                "text": "kube-public",
-                "value": "kube-public"
-              },
-              {
-                "selected": false,
-                "text": "kube-system",
-                "value": "kube-system"
-              },
-              {
-                "selected": false,
-                "text": "kubecost",
-                "value": "kubecost"
-              },
-              {
-                "selected": false,
-                "text": "kubedb",
-                "value": "kubedb"
-              },
-              {
-                "selected": false,
-                "text": "lmco",
-                "value": "lmco"
-              },
-              {
-                "selected": false,
-                "text": "loki",
-                "value": "loki"
-              },
-              {
-                "selected": false,
-                "text": "monitoring",
-                "value": "monitoring"
-              },
-              {
-                "selected": false,
-                "text": "threatstack",
-                "value": "threatstack"
-              },
-              {
-                "selected": false,
-                "text": "vault",
-                "value": "vault"
-              },
-              {
-                "selected": true,
-                "text": "vault-secrets-webhook",
-                "value": "vault-secrets-webhook"
-              },
-              {
-                "selected": false,
-                "text": "velero",
-                "value": "velero"
-              }
-            ],
+            "options": [],
             "query": "label_values(namespace)",
-            "refresh": 0,
+            "refresh": 2,
             "regex": ".*",
             "skipUrlSync": false,
             "sort": 0,
@@ -295,9 +169,13 @@ data:
           {
             "allValue": null,
             "current": {
-              "selected": false,
-              "text": "All",
-              "value": "$__all"
+              "selected": true,
+              "text": [
+                "All"
+              ],
+              "value": [
+                "$__all"
+              ]
             },
             "datasource": "Prometheus",
             "definition": "label_values(container_file_descriptors{namespace=~\"$namespace\"}, pod)",
@@ -306,26 +184,10 @@ data:
             "label": "",
             "multi": true,
             "name": "pod",
-            "options": [
-              {
-                "selected": true,
-                "text": "All",
-                "value": "$__all"
-              },
-              {
-                "selected": false,
-                "text": "secrets-webhook-vault-secrets-webhook-6cf8b9dd58-g76tk",
-                "value": "secrets-webhook-vault-secrets-webhook-6cf8b9dd58-g76tk"
-              },
-              {
-                "selected": false,
-                "text": "secrets-webhook-vault-secrets-webhook-6cf8b9dd58-r4wc8",
-                "value": "secrets-webhook-vault-secrets-webhook-6cf8b9dd58-r4wc8"
-              }
-            ],
+            "options": [],
             "query": "label_values(container_file_descriptors{namespace=~\"$namespace\"}, pod)",
-            "refresh": 0,
-            "regex": ".*",
+            "refresh": 2,
+            "regex": "/.*/",
             "skipUrlSync": false,
             "sort": 1,
             "tagValuesQuery": "",
@@ -337,12 +199,12 @@ data:
         ]
       },
       "time": {
-        "from": "now-2d",
+        "from": "now-3h",
         "to": "now"
       },
       "timepicker": {},
       "timezone": "",
-      "title": "FileDescriptorUsagebyNamespace",
-      "uid": "QVl8CCuMk",
-      "version": 4
+      "title": "FileDescriptors Usage by Namespace",
+      "uid": "dd36099e2ba9085b9a69b419a1058e8e5e20ea2c",
+      "version": 1
     }

--- a/helm-chart-sources/bluescape-monitoring-dashboards/templates/80_filedescriptors_by_ns/configmap.yaml
+++ b/helm-chart-sources/bluescape-monitoring-dashboards/templates/80_filedescriptors_by_ns/configmap.yaml
@@ -1,0 +1,348 @@
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: filedescriptorusagebynamespace-dashboard
+  namespace: grafana
+  labels:
+     {{- include "bluescape-monitoring-dashboards.labels" . | nindent 4 }}
+data:
+  filedescriptorusagebynamespace-dashboard.json: |-
+    {
+      "annotations": {
+        "list": [
+          {
+            "builtIn": 1,
+            "datasource": "-- Grafana --",
+            "enable": true,
+            "hide": true,
+            "iconColor": "rgba(0, 211, 255, 1)",
+            "name": "Annotations & Alerts",
+            "type": "dashboard"
+          }
+        ]
+      },
+      "editable": true,
+      "gnetId": null,
+      "graphTooltip": 0,
+      "id": 53,
+      "iteration": 1619042641217,
+      "links": [],
+      "panels": [
+        {
+          "aliasColors": {},
+          "bars": false,
+          "dashLength": 10,
+          "dashes": false,
+          "datasource": "Prometheus",
+          "description": "view file descriptor use by selection of specific [sets of] resources",
+          "fieldConfig": {
+            "defaults": {
+              "custom": {}
+            },
+            "overrides": []
+          },
+          "fill": 1,
+          "fillGradient": 0,
+          "gridPos": {
+            "h": 9,
+            "w": 24,
+            "x": 0,
+            "y": 0
+          },
+          "hiddenSeries": false,
+          "id": 2,
+          "legend": {
+            "alignAsTable": true,
+            "avg": false,
+            "current": true,
+            "max": true,
+            "min": false,
+            "rightSide": false,
+            "show": true,
+            "total": false,
+            "values": true
+          },
+          "lines": true,
+          "linewidth": 1,
+          "nullPointMode": "null",
+          "options": {
+            "alertThreshold": true
+          },
+          "percentage": false,
+          "pluginVersion": "7.2.2",
+          "pointradius": 2,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "spaceLength": 10,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "expr": "sum(container_file_descriptors{container!=\"POD\", namespace=~\"${namespace}\", pod=~\"${pod}\"}) by (node, namespace, pod)",
+              "interval": "",
+              "legendFormat": "{{ `{{node}}: {{pod}}` }}",
+              "refId": "A"
+            }
+          ],
+          "thresholds": [],
+          "timeFrom": null,
+          "timeRegions": [],
+          "timeShift": null,
+          "title": "File Descriptor Use by Resource",
+          "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+          },
+          "type": "graph",
+          "xaxis": {
+            "buckets": null,
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "$$hashKey": "object:193",
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            },
+            {
+              "$$hashKey": "object:194",
+              "format": "short",
+              "label": "",
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            }
+          ],
+          "yaxis": {
+            "align": false,
+            "alignLevel": null
+          }
+        }
+      ],
+      "schemaVersion": 26,
+      "style": "dark",
+      "tags": [],
+      "templating": {
+        "list": [
+          {
+            "allValue": null,
+            "current": {
+              "selected": true,
+              "tags": [],
+              "text": [
+                "vault-secrets-webhook"
+              ],
+              "value": [
+                "vault-secrets-webhook"
+              ]
+            },
+            "datasource": "Prometheus",
+            "definition": "label_values(namespace)",
+            "hide": 0,
+            "includeAll": true,
+            "label": "Namespace",
+            "multi": true,
+            "name": "namespace",
+            "options": [
+              {
+                "selected": false,
+                "text": "All",
+                "value": "$__all"
+              },
+              {
+                "selected": false,
+                "text": "ambassador",
+                "value": "ambassador"
+              },
+              {
+                "selected": false,
+                "text": "argocd",
+                "value": "argocd"
+              },
+              {
+                "selected": false,
+                "text": "auth-system",
+                "value": "auth-system"
+              },
+              {
+                "selected": false,
+                "text": "cert-manager",
+                "value": "cert-manager"
+              },
+              {
+                "selected": false,
+                "text": "cluster-autoscaler",
+                "value": "cluster-autoscaler"
+              },
+              {
+                "selected": false,
+                "text": "default",
+                "value": "default"
+              },
+              {
+                "selected": false,
+                "text": "dex",
+                "value": "dex"
+              },
+              {
+                "selected": false,
+                "text": "external-dns",
+                "value": "external-dns"
+              },
+              {
+                "selected": false,
+                "text": "external-secrets",
+                "value": "external-secrets"
+              },
+              {
+                "selected": false,
+                "text": "grafana",
+                "value": "grafana"
+              },
+              {
+                "selected": false,
+                "text": "ingress-nginx",
+                "value": "ingress-nginx"
+              },
+              {
+                "selected": false,
+                "text": "kafka",
+                "value": "kafka"
+              },
+              {
+                "selected": false,
+                "text": "kube-node-lease",
+                "value": "kube-node-lease"
+              },
+              {
+                "selected": false,
+                "text": "kube-public",
+                "value": "kube-public"
+              },
+              {
+                "selected": false,
+                "text": "kube-system",
+                "value": "kube-system"
+              },
+              {
+                "selected": false,
+                "text": "kubecost",
+                "value": "kubecost"
+              },
+              {
+                "selected": false,
+                "text": "kubedb",
+                "value": "kubedb"
+              },
+              {
+                "selected": false,
+                "text": "lmco",
+                "value": "lmco"
+              },
+              {
+                "selected": false,
+                "text": "loki",
+                "value": "loki"
+              },
+              {
+                "selected": false,
+                "text": "monitoring",
+                "value": "monitoring"
+              },
+              {
+                "selected": false,
+                "text": "threatstack",
+                "value": "threatstack"
+              },
+              {
+                "selected": false,
+                "text": "vault",
+                "value": "vault"
+              },
+              {
+                "selected": true,
+                "text": "vault-secrets-webhook",
+                "value": "vault-secrets-webhook"
+              },
+              {
+                "selected": false,
+                "text": "velero",
+                "value": "velero"
+              }
+            ],
+            "query": "label_values(namespace)",
+            "refresh": 0,
+            "regex": ".*",
+            "skipUrlSync": false,
+            "sort": 0,
+            "tagValuesQuery": "",
+            "tags": [],
+            "tagsQuery": "",
+            "type": "query",
+            "useTags": false
+          },
+          {
+            "allValue": null,
+            "current": {
+              "selected": false,
+              "text": "All",
+              "value": "$__all"
+            },
+            "datasource": "Prometheus",
+            "definition": "label_values(container_file_descriptors{namespace=~\"$namespace\"}, pod)",
+            "hide": 0,
+            "includeAll": true,
+            "label": "",
+            "multi": true,
+            "name": "pod",
+            "options": [
+              {
+                "selected": true,
+                "text": "All",
+                "value": "$__all"
+              },
+              {
+                "selected": false,
+                "text": "secrets-webhook-vault-secrets-webhook-6cf8b9dd58-g76tk",
+                "value": "secrets-webhook-vault-secrets-webhook-6cf8b9dd58-g76tk"
+              },
+              {
+                "selected": false,
+                "text": "secrets-webhook-vault-secrets-webhook-6cf8b9dd58-r4wc8",
+                "value": "secrets-webhook-vault-secrets-webhook-6cf8b9dd58-r4wc8"
+              }
+            ],
+            "query": "label_values(container_file_descriptors{namespace=~\"$namespace\"}, pod)",
+            "refresh": 0,
+            "regex": ".*",
+            "skipUrlSync": false,
+            "sort": 1,
+            "tagValuesQuery": "",
+            "tags": [],
+            "tagsQuery": "",
+            "type": "query",
+            "useTags": false
+          }
+        ]
+      },
+      "time": {
+        "from": "now-2d",
+        "to": "now"
+      },
+      "timepicker": {},
+      "timezone": "",
+      "title": "FileDescriptorUsagebyNamespace",
+      "uid": "QVl8CCuMk",
+      "version": 4
+    }

--- a/helm-chart-sources/bluescape-monitoring-dashboards/templates/80_filedescriptors_by_ns/dashboard.yaml
+++ b/helm-chart-sources/bluescape-monitoring-dashboards/templates/80_filedescriptors_by_ns/dashboard.yaml
@@ -2,12 +2,12 @@
 apiVersion: integreatly.org/v1alpha1
 kind: GrafanaDashboard
 metadata:
-  name: filedescriptorusagebynamespace-dashboard
+  name: filedescriptors-usage-by-namespace-dashboard
   namespace: grafana
   labels:
      {{- include "bluescape-monitoring-dashboards.labels" . | nindent 4 }}
 spec:
-  name: filedescriptorusagebynamespace-dashboard
+  name: filedescriptors-usage-by-namespace-dashboard
   configMapRef:
-    name: filedescriptorusagebynamespace-dashboard
-    key: filedescriptorusagebynamespace-dashboard.json
+    name: filedescriptors-usage-by-namespace-dashboard
+    key: filedescriptors-usage-by-namespace-dashboard.json

--- a/helm-chart-sources/bluescape-monitoring-dashboards/templates/80_filedescriptors_by_ns/dashboard.yaml
+++ b/helm-chart-sources/bluescape-monitoring-dashboards/templates/80_filedescriptors_by_ns/dashboard.yaml
@@ -1,0 +1,13 @@
+---
+apiVersion: integreatly.org/v1alpha1
+kind: GrafanaDashboard
+metadata:
+  name: filedescriptorusagebynamespace-dashboard
+  namespace: grafana
+  labels:
+     {{- include "bluescape-monitoring-dashboards.labels" . | nindent 4 }}
+spec:
+  name: filedescriptorusagebynamespace-dashboard
+  configMapRef:
+    name: filedescriptorusagebynamespace-dashboard
+    key: filedescriptorusagebynamespace-dashboard.json

--- a/helm-chart-sources/bluescape-monitoring-dashboards/templates/81_node_filedescriptors/configmap.yaml
+++ b/helm-chart-sources/bluescape-monitoring-dashboards/templates/81_node_filedescriptors/configmap.yaml
@@ -1,0 +1,555 @@
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: node-file-descriptors-dashboard
+  namespace: grafana
+  labels:
+     {{- include "bluescape-monitoring-dashboards.labels" . | nindent 4 }}
+data:
+  node-file-descriptors-dashboard.json: |-
+    {
+      "annotations": {
+        "list": [
+          {
+            "builtIn": 1,
+            "datasource": "-- Grafana --",
+            "enable": true,
+            "hide": true,
+            "iconColor": "rgba(0, 211, 255, 1)",
+            "name": "Annotations & Alerts",
+            "type": "dashboard"
+          }
+        ]
+      },
+      "description": "file descriptors, used, available metrics",
+      "editable": true,
+      "gnetId": 3089,
+      "graphTooltip": 0,
+      "id": 51,
+      "iteration": 1619032682310,
+      "links": [],
+      "panels": [
+        {
+          "aliasColors": {},
+          "bars": false,
+          "dashLength": 10,
+          "dashes": false,
+          "datasource": null,
+          "fieldConfig": {
+            "defaults": {
+              "custom": {}
+            },
+            "overrides": []
+          },
+          "fill": 1,
+          "fillGradient": 0,
+          "gridPos": {
+            "h": 5,
+            "w": 24,
+            "x": 0,
+            "y": 0
+          },
+          "hiddenSeries": false,
+          "id": 13,
+          "legend": {
+            "alignAsTable": true,
+            "avg": false,
+            "current": true,
+            "max": true,
+            "min": false,
+            "rightSide": true,
+            "show": true,
+            "sideWidth": 315,
+            "total": false,
+            "values": true
+          },
+          "lines": true,
+          "linewidth": 1,
+          "nullPointMode": "null",
+          "options": {
+            "alertThreshold": true
+          },
+          "percentage": false,
+          "pluginVersion": "7.2.2",
+          "pointradius": 2,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "spaceLength": 10,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "expr": "sum(container_file_descriptors{instance=~\"${node}:.*\"}) by (node)",
+              "hide": false,
+              "interval": "",
+              "legendFormat": "{{ `{{node}}` }}",
+              "refId": "A"
+            }
+          ],
+          "thresholds": [],
+          "timeFrom": null,
+          "timeRegions": [],
+          "timeShift": null,
+          "title": "Node Container Descriptors",
+          "tooltip": {
+            "shared": true,
+            "sort": 2,
+            "value_type": "individual"
+          },
+          "type": "graph",
+          "xaxis": {
+            "buckets": null,
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "$$hashKey": "object:439",
+              "format": "none",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            },
+            {
+              "$$hashKey": "object:440",
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            }
+          ],
+          "yaxis": {
+            "align": false,
+            "alignLevel": null
+          }
+        },
+        {
+          "aliasColors": {},
+          "bars": false,
+          "dashLength": 10,
+          "dashes": false,
+          "datasource": "Prometheus",
+          "fieldConfig": {
+            "defaults": {
+              "custom": {}
+            },
+            "overrides": []
+          },
+          "fill": 1,
+          "fillGradient": 0,
+          "gridPos": {
+            "h": 5,
+            "w": 24,
+            "x": 0,
+            "y": 5
+          },
+          "hiddenSeries": false,
+          "id": 5,
+          "legend": {
+            "alignAsTable": true,
+            "avg": false,
+            "current": true,
+            "max": true,
+            "min": false,
+            "rightSide": true,
+            "show": true,
+            "sideWidth": 260,
+            "total": false,
+            "values": true
+          },
+          "lines": true,
+          "linewidth": 1,
+          "links": [],
+          "nullPointMode": "null",
+          "options": {
+            "alertThreshold": true
+          },
+          "percentage": false,
+          "pluginVersion": "7.2.2",
+          "pointradius": 5,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "spaceLength": 10,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "expr": "node_filefd_allocated{job=\"node-exporter\",instance=~\"$node:$port\"}",
+              "format": "time_series",
+              "hide": false,
+              "interval": "",
+              "intervalFactor": 1,
+              "legendFormat": "allocated",
+              "refId": "B",
+              "step": 4,
+              "target": ""
+            },
+            {
+              "expr": "node_filefd_maximum{job=\"node-exporter\",instance=~\"$node:$port\"}",
+              "format": "time_series",
+              "hide": true,
+              "interval": "",
+              "intervalFactor": 1,
+              "legendFormat": "maximum",
+              "refId": "I",
+              "step": 4,
+              "target": ""
+            }
+          ],
+          "thresholds": [],
+          "timeFrom": null,
+          "timeRegions": [],
+          "timeShift": null,
+          "title": "File Descriptors",
+          "tooltip": {
+            "shared": true,
+            "sort": 2,
+            "value_type": "individual"
+          },
+          "type": "graph",
+          "xaxis": {
+            "buckets": null,
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "format": "none",
+              "label": "",
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            },
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            }
+          ],
+          "yaxis": {
+            "align": false,
+            "alignLevel": null
+          }
+        },
+        {
+          "aliasColors": {},
+          "bars": false,
+          "dashLength": 10,
+          "dashes": false,
+          "datasource": "Prometheus",
+          "decimals": 1,
+          "fieldConfig": {
+            "defaults": {
+              "custom": {}
+            },
+            "overrides": []
+          },
+          "fill": 1,
+          "fillGradient": 0,
+          "gridPos": {
+            "h": 5,
+            "w": 24,
+            "x": 0,
+            "y": 10
+          },
+          "hiddenSeries": false,
+          "id": 11,
+          "legend": {
+            "alignAsTable": true,
+            "avg": true,
+            "current": true,
+            "max": false,
+            "min": false,
+            "rightSide": true,
+            "show": true,
+            "sideWidth": 275,
+            "total": false,
+            "values": true
+          },
+          "lines": true,
+          "linewidth": 1,
+          "links": [],
+          "nullPointMode": "null",
+          "options": {
+            "alertThreshold": true
+          },
+          "percentage": false,
+          "pluginVersion": "7.2.2",
+          "pointradius": 5,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "spaceLength": 10,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "expr": "node_filesystem_size_bytes{job=\"node-exporter\",instance=~\"$node:$port\",device!~\"/dev/loop.*\",device!~\"tmpfs|nsfs\",device!=\"gvfsd-fuse\"} - node_filesystem_avail_bytes{job=\"node-exporter\",instance=~\"$node:$port\"}",
+              "format": "time_series",
+              "hide": false,
+              "interval": "",
+              "intervalFactor": 1,
+              "legendFormat": "{{ `{{device}}` }}",
+              "refId": "B",
+              "step": 4,
+              "target": ""
+            }
+          ],
+          "thresholds": [],
+          "timeFrom": null,
+          "timeRegions": [],
+          "timeShift": null,
+          "title": "Used",
+          "tooltip": {
+            "shared": true,
+            "sort": 2,
+            "value_type": "individual"
+          },
+          "type": "graph",
+          "xaxis": {
+            "buckets": null,
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "format": "bytes",
+              "label": "",
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            },
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            }
+          ],
+          "yaxis": {
+            "align": false,
+            "alignLevel": null
+          }
+        },
+        {
+          "aliasColors": {},
+          "bars": false,
+          "dashLength": 10,
+          "dashes": false,
+          "datasource": "Prometheus",
+          "decimals": 1,
+          "fieldConfig": {
+            "defaults": {
+              "custom": {}
+            },
+            "overrides": []
+          },
+          "fill": 1,
+          "fillGradient": 0,
+          "gridPos": {
+            "h": 5,
+            "w": 24,
+            "x": 0,
+            "y": 15
+          },
+          "hiddenSeries": false,
+          "id": 6,
+          "legend": {
+            "alignAsTable": true,
+            "avg": false,
+            "current": true,
+            "max": true,
+            "min": false,
+            "rightSide": true,
+            "show": true,
+            "sideWidth": 285,
+            "total": false,
+            "values": true
+          },
+          "lines": true,
+          "linewidth": 1,
+          "links": [],
+          "nullPointMode": "null",
+          "options": {
+            "alertThreshold": true
+          },
+          "percentage": false,
+          "pluginVersion": "7.2.2",
+          "pointradius": 5,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "spaceLength": 10,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "expr": "node_filesystem_avail_bytes{job=\"node-exporter\",instance=~\"$node:$port\",device!~\"/dev/loop.*\",device!~\"tmpfs|nsfs\",device!=\"gvfsd-fuse\"}",
+              "format": "time_series",
+              "hide": false,
+              "interval": "",
+              "intervalFactor": 1,
+              "legendFormat": "{{ `{{device}}` }}",
+              "refId": "B",
+              "step": 4,
+              "target": ""
+            }
+          ],
+          "thresholds": [],
+          "timeFrom": null,
+          "timeRegions": [],
+          "timeShift": null,
+          "title": "Available",
+          "tooltip": {
+            "shared": true,
+            "sort": 2,
+            "value_type": "individual"
+          },
+          "type": "graph",
+          "xaxis": {
+            "buckets": null,
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "format": "bytes",
+              "label": "",
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            },
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            }
+          ],
+          "yaxis": {
+            "align": false,
+            "alignLevel": null
+          }
+        }
+      ],
+      "refresh": "5m",
+      "schemaVersion": 26,
+      "style": "dark",
+      "tags": [],
+      "templating": {
+        "list": [
+          {
+            "allValue": null,
+            "current": {
+              "selected": true,
+              "tags": [],
+              "text": [
+                "10.67.71.87",
+                "10.67.66.102"
+              ],
+              "value": [
+                "10.67.71.87",
+                "10.67.66.102"
+              ]
+            },
+            "datasource": "Prometheus",
+            "definition": "label_values(node_cpu_seconds_total{job=\"node-exporter\"}, instance)",
+            "hide": 0,
+            "includeAll": true,
+            "label": null,
+            "multi": true,
+            "name": "node",
+            "options": [],
+            "query": "label_values(node_cpu_seconds_total{job=\"node-exporter\"}, instance)",
+            "refresh": 1,
+            "regex": "/([^:]+):.*/",
+            "skipUrlSync": false,
+            "sort": 3,
+            "tagValuesQuery": "",
+            "tags": [],
+            "tagsQuery": "",
+            "type": "query",
+            "useTags": false
+          },
+          {
+            "allValue": null,
+            "current": {
+              "selected": false,
+              "text": "9100",
+              "value": "9100"
+            },
+            "datasource": "Prometheus",
+            "definition": "label_values(node_cpu_seconds_total{job=\"node-exporter\"}, instance)",
+            "hide": 2,
+            "includeAll": false,
+            "label": null,
+            "multi": false,
+            "name": "port",
+            "options": [],
+            "query": "label_values(node_cpu_seconds_total{job=\"node-exporter\"}, instance)",
+            "refresh": 1,
+            "regex": "/[^:]+:(.*)/",
+            "skipUrlSync": false,
+            "sort": 0,
+            "tagValuesQuery": "",
+            "tags": [],
+            "tagsQuery": "",
+            "type": "query",
+            "useTags": false
+          }
+        ]
+      },
+      "time": {
+        "from": "now-2d",
+        "to": "now"
+      },
+      "timepicker": {
+        "refresh_intervals": [
+          "5s",
+          "10s",
+          "30s",
+          "1m",
+          "5m"
+        ],
+        "time_options": [
+          "5m",
+          "15m",
+          "1h",
+          "6h",
+          "12h",
+          "24h",
+          "2d",
+          "7d",
+          "30d"
+        ]
+      },
+      "timezone": "browser",
+      "title": "Node File Descriptors",
+      "uid": "000000007",
+      "version": 14
+    }

--- a/helm-chart-sources/bluescape-monitoring-dashboards/templates/81_node_filedescriptors/configmap.yaml
+++ b/helm-chart-sources/bluescape-monitoring-dashboards/templates/81_node_filedescriptors/configmap.yaml
@@ -26,8 +26,8 @@ data:
       "editable": true,
       "gnetId": 3089,
       "graphTooltip": 0,
-      "id": 51,
-      "iteration": 1619110314782,
+      "id": 132,
+      "iteration": 1619141873208,
       "links": [],
       "panels": [
         {
@@ -188,7 +188,7 @@ data:
               "hide": false,
               "interval": "",
               "intervalFactor": 1,
-              "legendFormat": "allocated",
+              "legendFormat": "{{ `{{instance}}` }}",
               "refId": "B",
               "step": 4,
               "target": ""
@@ -225,6 +225,7 @@ data:
           },
           "yaxes": [
             {
+              "$$hashKey": "object:505",
               "format": "none",
               "label": "",
               "logBase": 1,
@@ -233,6 +234,7 @@ data:
               "show": true
             },
             {
+              "$$hashKey": "object:506",
               "format": "short",
               "label": null,
               "logBase": 1,
@@ -304,7 +306,7 @@ data:
               "hide": false,
               "interval": "",
               "intervalFactor": 1,
-              "legendFormat": "{{ `{{device}}` }}",
+              "legendFormat": "{{ `{{instance}}:{{device}}` }}",
               "refId": "B",
               "step": 4,
               "target": ""
@@ -409,7 +411,7 @@ data:
               "hide": false,
               "interval": "",
               "intervalFactor": 1,
-              "legendFormat": "{{ `{{device}}` }}",
+              "legendFormat": "{{ `{{instance}}:{{device}}` }}",
               "refId": "B",
               "step": 4,
               "target": ""
@@ -466,7 +468,7 @@ data:
           {
             "allValue": null,
             "current": {
-              "selected": true,
+              "selected": false,
               "text": "All",
               "value": "$__all"
             },
@@ -543,6 +545,6 @@ data:
       },
       "timezone": "browser",
       "title": "Node File Descriptors",
-      "uid": "000000007",
-      "version": 15
+      "uid": "aeaff25c9780c3ba9bc091e9f5b4cf9c92ffbf9c",
+      "version": 2
     }

--- a/helm-chart-sources/bluescape-monitoring-dashboards/templates/81_node_filedescriptors/configmap.yaml
+++ b/helm-chart-sources/bluescape-monitoring-dashboards/templates/81_node_filedescriptors/configmap.yaml
@@ -27,7 +27,7 @@ data:
       "gnetId": 3089,
       "graphTooltip": 0,
       "id": 51,
-      "iteration": 1619032682310,
+      "iteration": 1619110314782,
       "links": [],
       "panels": [
         {
@@ -467,29 +467,22 @@ data:
             "allValue": null,
             "current": {
               "selected": true,
-              "tags": [],
-              "text": [
-                "10.67.71.87",
-                "10.67.66.102"
-              ],
-              "value": [
-                "10.67.71.87",
-                "10.67.66.102"
-              ]
+              "text": "All",
+              "value": "$__all"
             },
             "datasource": "Prometheus",
             "definition": "label_values(node_cpu_seconds_total{job=\"node-exporter\"}, instance)",
             "hide": 0,
             "includeAll": true,
             "label": null,
-            "multi": true,
+            "multi": false,
             "name": "node",
             "options": [],
             "query": "label_values(node_cpu_seconds_total{job=\"node-exporter\"}, instance)",
             "refresh": 1,
             "regex": "/([^:]+):.*/",
             "skipUrlSync": false,
-            "sort": 3,
+            "sort": 1,
             "tagValuesQuery": "",
             "tags": [],
             "tagsQuery": "",
@@ -525,7 +518,7 @@ data:
         ]
       },
       "time": {
-        "from": "now-2d",
+        "from": "now-3h",
         "to": "now"
       },
       "timepicker": {
@@ -551,5 +544,5 @@ data:
       "timezone": "browser",
       "title": "Node File Descriptors",
       "uid": "000000007",
-      "version": 14
+      "version": 15
     }

--- a/helm-chart-sources/bluescape-monitoring-dashboards/templates/81_node_filedescriptors/dashboard.yaml
+++ b/helm-chart-sources/bluescape-monitoring-dashboards/templates/81_node_filedescriptors/dashboard.yaml
@@ -1,0 +1,13 @@
+---
+apiVersion: integreatly.org/v1alpha1
+kind: GrafanaDashboard
+metadata:
+  name: node-file-descriptors-dashboard
+  namespace: grafana
+  labels:
+     {{- include "bluescape-monitoring-dashboards.labels" . | nindent 4 }}
+spec:
+  name: node-file-descriptors-dashboard
+  configMapRef:
+    name: node-file-descriptors-dashboard
+    key: node-file-descriptors-dashboard.json


### PR DESCRIPTION
These are filedescriptor usage dashboards; tested in atreus. Can be viewed in LMCO as well. Updated `README` as well. The instructions for `helm` installation were a little off in the original. Also note that I found a small "bug" (actually it was a feature but that feature borked things) in `json2yaml`. I'll be pushing a subsequent fix to that in the ops repo. This was causing issues with `helm` installation of some dashboards added with `add_dashboard `